### PR TITLE
Binds the events to $this instead of options[i] so that the callbacks ex...

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -736,9 +736,9 @@
 				});
 			}
 			$this.data('pickmeup-options', options);
-			for (i in options) {
+			for (var i in options) {
 				if ($.inArray(i, ['render', 'change', 'before_show', 'show', 'hide']) != -1) {
-					options[i]	= options[i].bind(this);
+					$this.bind(options[i]);
 				}
 			}
 			options.binded	= {


### PR DESCRIPTION
...ecute on the input in each() instead of the selector calling pickmeup - fixes #4
