### PR TITLE
update, get_date, set_date methods are not working

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -631,14 +631,14 @@
 				case 'clear':
 				case 'update':
 					this.each(function () {
-						data	= $(this).data('pickmeup-initial_options');
+						data	= $(this).data('pickmeup-options');
 						if (data) {
 							data.binded[initial_options]();
 						}
 					});
 				break;
 				case 'get_date':
-					data	= this.data('pickmeup-initial_options');
+					data	= this.data('pickmeup-options');
 					if (data) {
 						return data.binded.get_date(parameters[0]);
 					} else {
@@ -647,7 +647,7 @@
 				break;
 				case 'set_date':
 					this.each(function () {
-						data	= $(this).data('pickmeup-initial_options');
+						data	= $(this).data('pickmeup-options');
 						if (data) {
 							data.binded[initial_options].apply(this, parameters);
 						}


### PR DESCRIPTION
The methods `update`, `get_date`, `set_date` are not working in the latest version of library. It happened after [this commit](https://github.com/nazar-pc/PickMeUp/commit/3f846c7cac1a4663f31c300edcb4f08383f29047). It seems like accidentally `'pickmeup-options'` data attribute was replaced with incorrect one `'pickmeup-initial_options'`.  The pull-request resolves the issue. 
