### PR TITLE
Fixed: Days and month displayed as «NaN»

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -238,6 +238,8 @@
 			return date;
 		} else if (!date) {
 			return new Date;
+		} else if (isNaN(Date.parse(date))) {
+			return new Date;
 		}
 		var splitted_date	= date.split(separator);
 		if (splitted_date.length > 1) {


### PR DESCRIPTION
Fixed: Days and month displayed as «NaN» if is a «wrong» value in the text field. Если в текстовом поле «неправильное» значение, то дни и месяц отображаются как NaN.
