### PR TITLE
Add uniquify_dates option to return unique dates.

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -59,6 +59,7 @@
 		class_name		: '',
 		separator		: ' - ',
 		hide_on_select	: false,
+		uniquify_dates	: false,
 		min				: null,
 		max				: null,
 		render			: function () {},
@@ -676,6 +677,7 @@
 			return [formatDate(result, options.format, options.locale), result];
 		} else {
 			result = [[],[]];
+			if (options.uniquify_dates && options.date.filter) options.date = options.date.filter(function (e, i, arr) { return arr.lastIndexOf(e) === i; });
 			$.each(options.date, function(nr, val){
 				var date = new Date(val);
 				result[0].push(formatDate(date, options.format, options.locale));

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ All options and events are the same.
 | trigger_event   | string                | click touchstart | Event to trigger the date picker                                                                            |
 | class_name      | string                |                  | Class to be added to root datepicker element                                                                |
 | hide_on_select  | boolean               | false            | If `true` - datepicker will be hidden after selection (for range mode allows to select first and last days) |
+| uniquify_dates  | boolean               | false            | If `true` - dates returned will be unique (for range mode if start and end date the same)                   |
 | min             | null/object/string    | null             | Min date available for selection, `null` means no limitation                                                |
 | max             | null/object/string    | null             | Max date available for selection, `null` means no limitation                                                |
 | separator       | string                | ` - `            | Is used for joining separate dates in multiple mode and first/last dates in range mode                      |


### PR DESCRIPTION
Adds option to return unique dates - useful for range mode so that if start and end date the same then only one date returned (more natural looking). Uses array.filter so won't work for IE8.
