### PR TITLE
New alignment option and default static offset for multiple calendar views.

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -615,7 +615,7 @@
 		}
 	}
 	function align(options){
-		if (options.alignment === parseInt(options.alignment, 10)) {
+		if ($.isNumeric(options.alignment)) {
 			return options.alignment;
 		}
 		switch(options.alignment){
@@ -710,12 +710,12 @@
 					options.current.addMonths(instance_index - align(options));
 					if (el.hasClass('pmu-not-in-month')) {
 						options.current.addMonths(val > 15 ? -1 : 1);
-						if (options.alignment === parseInt(options.alignment, 10)) {
+						if ($.isNumeric(options.alignment)) {
 							instance_index = instance_index + (val > 15 ? -1 : 1);
 							options.alignment = instance_index;
 						}
 					}
-					if (options.alignment === parseInt(options.alignment, 10)) {
+					if ($.isNumeric(options.alignment)) {
 						options.alignment = instance_index;
 					}
 					options.current.setDate(val);

--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -67,6 +67,7 @@
 		select_day		: true,
 		view			: 'days',
 		calendars		: 1,
+		alignment		: 0,
 		format			: 'd-m-Y',
 		position		: 'bottom',
 		trigger_event	: 'click touchstart',
@@ -121,7 +122,7 @@
 	function fill () {
 		var options			= $(this).data('pickmeup-options'),
 			pickmeup		= this.pickmeup,
-			current_cal		= Math.floor(options.calendars / 2),
+			current_cal		= align(options),
 			actual_date		= options.date,
 			current_date	= options.current,
 			min_date		= options.min ? new Date(options.min) : null,
@@ -613,6 +614,23 @@
 			return false;
 		}
 	}
+	function align(options){
+		if (options.alignment === parseInt(options.alignment, 10)) {
+			return options.alignment;
+		}
+		switch(options.alignment){
+			case 'left':
+				return 0;
+				break;
+			case 'right':
+				return options.calendars - 1 ;
+				break;
+			case 'center':
+			default:
+				return Math.floor(options.calendars / 2);
+				break;
+		}
+	}
 	function click (e) {
 		var el	= $(e.target);
 		if (!el.hasClass('pmu-button')) {
@@ -629,7 +647,7 @@
 				instance_index	= $('.pmu-instance', root).index(instance);
 			if (el.parent().is('nav')) {
 				if (el.hasClass('pmu-month')) {
-					options.current.addMonths(instance_index - Math.floor(options.calendars / 2));
+					options.current.addMonths(instance_index - align(options));
 					if (root.hasClass('pmu-view-years')) {
 						// Shift back to current date, otherwise with min value specified may jump on few (tens) years forward
 						if (options.mode != 'single') {
@@ -681,12 +699,19 @@
 						options.binded.update_date();
 					}
 					// Move current month to the first place
-					options.current.addMonths(Math.floor(options.calendars / 2) - instance_index);
+					options.current.addMonths(align(options) - instance_index);
 				} else {
 					var val	= parseInt(el.text(), 10);
-					options.current.addMonths(instance_index - Math.floor(options.calendars / 2));
+					options.current.addMonths(instance_index - align(options));
 					if (el.hasClass('pmu-not-in-month')) {
 						options.current.addMonths(val > 15 ? -1 : 1);
+						if (options.alignment === parseInt(options.alignment, 10)) {
+							instance_index = instance_index + (val > 15 ? -1 : 1);
+							options.alignment = instance_index;
+						}
+					}
+					if (options.alignment === parseInt(options.alignment, 10)) {
+						options.alignment = instance_index;
 					}
 					options.current.setDate(val);
 					options.binded.update_date();

--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -687,21 +687,24 @@
 					options.current.setFullYear(parseInt(el.text(), 10));
 					if (options.select_month) {
 						root.removeClass('pmu-view-years').addClass('pmu-view-months');
-					} else if (options.select_day) {
+					  options.current.addYears(align(options) - instance_index);
+				} else if (options.select_day) {
 						root.removeClass('pmu-view-years').addClass('pmu-view-days');
-					} else {
+						options.current.addYears(align(options) - instance_index);
+		 		} else {
 						options.binded.update_date();
+						options.current.addYears(((align(options) - instance_index) * 12) - (instance.find('.pmu-years .pmu-button').index(el) - 6));
 					}
 				} else if (root.hasClass('pmu-view-months')) {
 					options.current.setMonth(instance.find('.pmu-months .pmu-button').index(el));
 					options.current.setFullYear(parseInt(instance.find('.pmu-month').text(), 10));
 					if (options.select_day) {
 						root.removeClass('pmu-view-months').addClass('pmu-view-days');
+						options.current.addMonths(align(options) - instance_index);
 					} else {
 						options.binded.update_date();
+ 					  options.current.addYears(align(options) - instance_index);
 					}
-					// Move current month to the first place
-					options.current.addMonths(align(options) - instance_index);
 				} else {
 					var val	= parseInt(el.text(), 10);
 					options.current.addMonths(instance_index - align(options));

--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -67,7 +67,7 @@
 		select_day		: true,
 		view			: 'days',
 		calendars		: 1,
-		alignment		: 0,
+		alignment		: 'static',
 		format			: 'd-m-Y',
 		position		: 'bottom',
 		trigger_event	: 'click touchstart',
@@ -619,6 +619,8 @@
 			return options.alignment;
 		}
 		switch(options.alignment){
+			case 'static':
+				options.alignment = 0;
 			case 'left':
 				return 0;
 				break;

--- a/readme.md
+++ b/readme.md
@@ -72,7 +72,7 @@ All options and events are the same.
 | select_year     | boolean                   | true             | Allow or deny year selection                                                                                         |
 | view            | days/months/years         | days             | View mode after initialization                                                                                       |
 | calendars       | int                       | 1                | Number of calendars, that will be rendered                                                                           |
-| alignment       | string/int                | 0                | Alignment method or static offset to use when there are multiple calendars. `right`, `left` or `center` default :0   | 
+| alignment       | string/int                | static           | Alignment method or static offset to use when there are multiple calendars. `static`,  `right`, `left` or `center`   | 
 | format          | string                    | d-m-Y            | Date format (aAbBCdeHIjklmMpPsSuwyY are supported)                                                                   |
 | position        | top/right/bottom/left     | bottom           | Date picker's position relative to the triggered element                                                             |
 | trigger_event   | string                    | click touchstart | Event to trigger the date picker                                                                                     |

--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,7 @@ All options and events are the same.
 | select_year     | boolean                   | true             | Allow or deny year selection                                                                                         |
 | view            | days/months/years         | days             | View mode after initialization                                                                                       |
 | calendars       | int                       | 1                | Number of calendars, that will be rendered                                                                           |
+| alignment       | string/int                | 0                | Alignment method or static offset to use when there are multiple calendars. `right`, `left` or `center` default :0   | 
 | format          | string                    | d-m-Y            | Date format (aAbBCdeHIjklmMpPsSuwyY are supported)                                                                   |
 | position        | top/right/bottom/left     | bottom           | Date picker's position relative to the triggered element                                                             |
 | trigger_event   | string                    | click touchstart | Event to trigger the date picker                                                                                     |


### PR DESCRIPTION
Default behavior for calendars is to stay in one place. Additional alignment can be done where the selected date is always `right` always, `left` or kept `center`.

Changes:
Added alignment function and properties.
Keep months in place when no alignment set.
Changed centered to center.
Added details on alignment configuration option to readme.

Fixes #41