### PR TITLE
Правка позиционирования календаря (метод show)

### DIFF
--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -765,14 +765,14 @@
 						top += this.offsetHeight;
 						break;
 				}
-				if (top + pickmeup.offsetHeight > viewport.t + viewport.h) {
-					top = pos.top  - pickmeup.offsetHeight;
+				if (top + pickmeup.outerHeight() > viewport.t + viewport.h) {
+					top = pos.top - pickmeup.outerHeight();
 				}
 				if (top < viewport.t) {
-					top = pos.top + this.offsetHeight + pickmeup.offsetHeight;
+					top = pos.top + this.offsetHeight;
 				}
-				if (left + pickmeup.offsetWidth > viewport.l + viewport.w) {
-					left = pos.left - pickmeup.offsetWidth;
+				if (left + pickmeup.outerWidth() > viewport.l + viewport.w) {
+					left = pos.left - pickmeup.outerWidth();
 				}
 				if (left < viewport.l) {
 					left = pos.left + this.offsetWidth

--- a/js/jquery.pickmeup.js
+++ b/js/jquery.pickmeup.js
@@ -728,8 +728,8 @@
 				options		= $this.data('pickmeup-options'),
 				pos			= $this.offset(),
 				viewport	= {
-					l : document.documentElement.scrollLeft,
-					t : document.documentElement.scrollTop,
+					l : window.pageXOffset || document.documentElement.scrollLeft,
+					t : window.pageYOffset || document.documentElement.scrollTop,
 					w : document.documentElement.clientWidth,
 					h : document.documentElement.clientHeight
 				},


### PR DESCRIPTION
1. Свойства элемента `document.documentElement.scrollTop` и `document.documentElement.scrollLeft`, которые содержат размеры прокрученной области, выдают на некоторых браузерах (к примеру, Chrome) не те результаты, которые нам нужны, вместо них следует использовать `window.pageYOffset` и `window.pageXOffset` соответственно, но при этом предыдущие свойства можно оставить как полифилл для браузеров, в которых не поддерживаются новые свойства (к примеру, IE8-).
2. Для получения ширины и высоты календаря используется свойства `offsetWidth` и `offsetHeight`, когда как календарь обернут в объект jQuery, в котором нет этих свойства. Поэтому следует использовать методы этой библиотеки такие как `outerWidth` и `outerHeight` соответственно.
3. Убрано вычисление высоты календаря в условие `top < viewport.t`, т.к. оно приводит к тому, что календарь позиционируется ниже (расстояние в размер его высоты) поля, где его вызывают.

P.S. к п. 2: можно, конечно, получить нужный нам DOM элемент через ключ `0` из jQuery объекта и использовать offsetWidth и offsetHeight, но эти свойства вернут нам `0`, так как элемент является скрытым `display: none`, когда как методы библиотеки возвращают размеры в независимости от этого.