### PR TITLE
Make sass variables "!default"

### DIFF
--- a/css/pickmeup.scss
+++ b/css/pickmeup.scss
@@ -6,22 +6,22 @@
  * @copyright	Copyright (c) 2008-2009, Stefan Petre
  * @license		MIT License, see license.txt
  */
-$border-radius						: .4em;
-$background							: #000;
-$color								: #eee;
-$background-hover					: transparent;
-$color-hover						: #88c5eb;
-$nav-color							: $color;
-$nav-color-hover					: $color-hover;
-$not-in-month						: #666;
-$not-in-month-hover					: #999;
-$disabled							: #333;
-$selected							: $color;
-$selected-background				: #136a9f;
-$not-in-month-selected-background	: #17384d;
-$day-of-week						: $not-in-month-hover;
-$today-background					: $not-in-month-selected-background;
-$today-color						: $color-hover;
+$border-radius						: .4em !default;
+$background							: #000 !default;
+$color								: #eee !default;
+$background-hover					: transparent !default;
+$color-hover						: #88c5eb !default;
+$nav-color							: $color !default;
+$nav-color-hover					: $color-hover !default;
+$not-in-month						: #666 !default;
+$not-in-month-hover					: #999 !default;
+$disabled							: #333 !default;
+$selected							: $color !default;
+$selected-background				: #136a9f !default;
+$not-in-month-selected-background	: #17384d !default;
+$day-of-week						: $not-in-month-hover !default;
+$today-background					: $not-in-month-selected-background !default;
+$today-color						: $color-hover !default;
 
 .pickmeup {
 	background      : $background;

--- a/css/pickmeup.scss
+++ b/css/pickmeup.scss
@@ -6,22 +6,22 @@
  * @copyright	Copyright (c) 2008-2009, Stefan Petre
  * @license		MIT License, see license.txt
  */
-$border-radius						: .4em !default;
-$background							: #000 !default;
-$color								: #eee !default;
-$background-hover					: transparent !default;
-$color-hover						: #88c5eb !default;
-$nav-color							: $color !default;
-$nav-color-hover					: $color-hover !default;
-$not-in-month						: #666 !default;
-$not-in-month-hover					: #999 !default;
-$disabled							: #333 !default;
-$selected							: $color !default;
-$selected-background				: #136a9f !default;
-$not-in-month-selected-background	: #17384d !default;
-$day-of-week						: $not-in-month-hover !default;
-$today-background					: $not-in-month-selected-background !default;
-$today-color						: $color-hover !default;
+$border-radius                    : .4em !default;
+$background                       : #000 !default;
+$color                            : #eee !default;
+$background-hover                 : transparent !default;
+$color-hover                      : #88c5eb !default;
+$nav-color                        : $color !default;
+$nav-color-hover                  : $color-hover !default;
+$not-in-month                     : #666 !default;
+$not-in-month-hover               : #999 !default;
+$disabled                         : #333 !default;
+$selected                         : $color !default;
+$selected-background              : #136a9f !default;
+$not-in-month-selected-background : #17384d !default;
+$day-of-week                      : $not-in-month-hover !default;
+$today-background                 : $not-in-month-selected-background !default;
+$today-color                      : $color-hover !default;
 
 .pickmeup {
 	background      : $background;


### PR DESCRIPTION
This allows uses to import the SASS file from PickMeUp using their own custom variables, without the need to alter the source files.
It is a better workflow for users who include PickMeUp via bower and other tools.

Also, I changed the variables indentation to spaces, so they look prettier on github.