### PR TITLE
fix Opera12 fail

### DIFF
--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -72,7 +72,7 @@
 	 * @returns {boolean}
 	 */
 	function dom_matches (element, selector) {
-		return (element.matches || element.webkitMatchesSelector || element.msMatchesSelector).call(element, selector);
+		return (element.matches || element.webkitMatchesSelector || element.msMatchesSelector || element.oMatchesSelector).call(element, selector);
 	}
 
 	/**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
Opera 11.5: `This feature was implemented with the non-standard name oMatchesSelector`