### PR TITLE
Allow styling of the calendar header parts

### DIFF
--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -308,7 +308,7 @@
 				header = local_date.getFullYear();
 			} else if (dom_has_class(root_element, 'pmu-view-days')) {
 				date_add_months(local_date, i - current_cal);
-				header = format_date(local_date, options.title_format, options.locales[options.locale]);
+				header = format_date(local_date, options.title_format, options.locales[options.locale], true);
 			}
 			if (!shown_date_to) {
 				if (max_date) {
@@ -632,7 +632,7 @@
 		return date;
 	}
 
-	function format_date (date, format, locale) {
+	function format_date (date, format, locale, html) {
 		var m  = date.getMonth();
 		var d  = date.getDate();
 		var y  = date.getFullYear();
@@ -717,7 +717,12 @@
 				default:
 					parts[i] = 'default';
 			}
-			parts[i] = '<span class="pmu-month-text-' + parts[i] + '">' + part + '</span>';
+			if (html) {
+				parts[i] = '<span class="pmu-month-text-' + parts[i] + '">' + part + '</span>';
+			}
+			else {
+				parts[i] = part;
+			}
 		}
 		return parts.join('');
 	}

--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -882,7 +882,6 @@
 
 	function prepare_date (options) {
 		var result;
-		console.log("preparing date")
 		if (options.mode == 'single') {
 			result = new Date(options.date);
 			return {

--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -308,7 +308,12 @@
 				header = local_date.getFullYear();
 			} else if (dom_has_class(root_element, 'pmu-view-days')) {
 				date_add_months(local_date, i - current_cal);
-				header = format_date(local_date, options.title_format, options.locales[options.locale], true);
+				if (typeof options.title_format === "function") {
+					header = options.title_format(local_date, options.locales[options.locale]);
+				}
+				else {
+					header = format_date(local_date, options.title_format, options.locales[options.locale]);
+				}
 			}
 			if (!shown_date_to) {
 				if (max_date) {
@@ -632,7 +637,7 @@
 		return date;
 	}
 
-	function format_date (date, format, locale, html) {
+	function format_date (date, format, locale) {
 		var m  = date.getMonth();
 		var d  = date.getDate();
 		var y  = date.getFullYear();
@@ -714,15 +719,8 @@
 				case 'Y':
 					part = y;
 					break;
-				default:
-					parts[i] = 'default';
 			}
-			if (html) {
-				parts[i] = '<span class="pmu-month-text-' + parts[i] + '">' + part + '</span>';
-			}
-			else {
-				parts[i] = part;
-			}
+			parts[i] = part;
 		}
 		return parts.join('');
 	}
@@ -884,6 +882,7 @@
 
 	function prepare_date (options) {
 		var result;
+		console.log("preparing date")
 		if (options.mode == 'single') {
 			result = new Date(options.date);
 			return {

--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -344,7 +344,7 @@
 					continue;
 				}
 			}
-			dom_query(instance, '.pmu-month').textContent = header;
+			dom_query(instance, '.pmu-month').innerHTML = header;
 			var is_year_selected                          = function (year) {
 				return (
 						options.mode == 'range' &&
@@ -714,8 +714,10 @@
 				case 'Y':
 					part = y;
 					break;
+				default:
+					parts[i] = 'default';
 			}
-			parts[i] = part;
+			parts[i] = '<span class="pmu-month-text-' + parts[i] + '">' + part + '</span>';
 		}
 		return parts.join('');
 	}


### PR DESCRIPTION
This change will allow the date parts to be styled individually using the same CSS suffix as the character used in the `title_format` option. For example:

```
.pickmeup .pmu-month-text-B {
  font-size: 1.5rem;
  color: #1cc1f8;
}
.pickmeup .pmu-month-text-Y {
  font-size: 0.8rem;
  color: #ccc;
}
.pickmeup .pmu-month-text-default {
  color: red;
  text-decoration: underline;
}
```
Will produce a title like:

https://imgur.com/a/ZgGnWkk

The only caveat is that CSS class selectors are case-insensitive, so `.pickmeup .pmu-month-text-B` will also match the same as `.pickmeup .pmu-month-text-b`, etc. 

I hope you like it.