### PR TITLE
Add ability to "select last day of month" from the calendar view.

### DIFF
--- a/js/pickmeup.js
+++ b/js/pickmeup.js
@@ -588,6 +588,7 @@
 					break;
 				case 'd':
 				case 'e':
+				case 't':
 					d = parseInt(parts[i], 10);
 					break;
 				case 'm':
@@ -705,6 +706,10 @@
 					break;
 				case 'S':
 					part = (sec < 10) ? ("0" + sec) : sec;
+					break;
+				case 't':
+					// Calculate the last day of the month
+					part = new Date(y, m + 1, 0).getDate();
 					break;
 				case 'u':
 					part = w + 1;


### PR DESCRIPTION
Add ability to "select last day of month" from the calendar view.

- Use select_day: false, format the day using 't' instead of 'd'
  't' mirrors the format string in PHP's date() command where 't'
  yields the number of days in the month.

Why is this useful?  In my application, I want to select the year and month and have the calendar give me a formatted date with the last day of that month instead of the first.  